### PR TITLE
legacy browser support

### DIFF
--- a/addon/listeners/key-events.js
+++ b/addon/listeners/key-events.js
@@ -8,7 +8,7 @@ const validKeys = keyMapValues.concat(['alt', 'ctrl', 'meta', 'shift']);
 
 const validateKeys = function validateKeys(keys) {
   keys.forEach((key) => {
-    if (!validKeys.includes(key)) {
+    if (validKeys.indexOf(key) === -1) {
       error(`\`${key}\` is not a valid key name`);
     }
   });


### PR DESCRIPTION
`Array.prototype.includes()` does not get transpiled by babel and is not available in the vast majority of browsers yet. This PR uses the ES5 equivalent of containment checking instead.