### PR TITLE
Add note to demo documentation regarding common pattern mixins

### DIFF
--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -84,6 +84,8 @@ Controls:
 
 To reduce boilerplate, `ember-keyboard` includes several mixins with common patterns.
 
+**Note: these are used alongside `EKMixin`, it must be included as well for these to work.**
+
 ### EKOnInsertMixin
 
 `import { EKOnInsertMixin } from 'ember-keyboard';`


### PR DESCRIPTION
Add note to docs that EKMixin must be used as well as any "common pattern" mixins

While this could be determined by a simple look at the actual mixin code, I feel like a quick note like this might be helpful, and would have saved me 5 minutes or so of confusion :smile: 