### PR TITLE
Bugfix: getKey should always return the non-modified key value in the event

### DIFF
--- a/addon/utils/get-key.js
+++ b/addon/utils/get-key.js
@@ -1,5 +1,5 @@
 import KEY_MAP from 'ember-keyboard/fixtures/key-map';
 
 export default function getKey(event) {
-  return event.key || KEY_MAP[event.keyCode];
+  return KEY_MAP[event.keyCode] || event.key;
 }


### PR DESCRIPTION
When a physical key is pressed alongside a modifier, the key value (not to be confused with keyCode) should always be the lower case/non-modified variant of the physical key