### PR TITLE
Deactivating 'keyboardActivated' as well as 'keyboardFirstResponder' …

### DIFF
--- a/addon/initializers/ember-keyboard-first-responder-inputs.js
+++ b/addon/initializers/ember-keyboard-first-responder-inputs.js
@@ -7,8 +7,22 @@ const {
 } = Ember;
 
 export function initialize() {
-  TextField.reopen(EKMixin, EKFirstResponderOnFocusMixin);
-  TextArea.reopen(EKMixin, EKFirstResponderOnFocusMixin);
+  TextField.reopen(EKMixin, EKFirstResponderOnFocusMixin, {
+    resignFirstResponderOnFocusOut: on('focusOut', function() {
+      setProperties(this, {
+        keyboardActivated: false,
+        keyboardFirstResponder: false
+      });
+    })
+  });
+  TextArea.reopen(EKMixin, EKFirstResponderOnFocusMixin, {
+    resignFirstResponderOnFocusOut: on('focusOut', function() {
+      setProperties(this, {
+        keyboardActivated: false,
+        keyboardFirstResponder: false
+      });
+    })
+  });
 }
 
 export default {

--- a/addon/mixins/keyboard-first-responder-on-focus.js
+++ b/addon/mixins/keyboard-first-responder-on-focus.js
@@ -16,6 +16,6 @@ export default Mixin.create({
   }),
 
   resignFirstResponderOnFocusOut: on('focusOut', function() {
-    set('keyboardActivated', false);
+    set('keyboardFirstResponder', false);
   })
 });

--- a/addon/mixins/keyboard-first-responder-on-focus.js
+++ b/addon/mixins/keyboard-first-responder-on-focus.js
@@ -16,9 +16,6 @@ export default Mixin.create({
   }),
 
   resignFirstResponderOnFocusOut: on('focusOut', function() {
-    setProperties(this, {
-      keyboardActivated: false,
-      keyboardFirstResponder: false
-    });
+    set('keyboardActivated', false);
   })
 });

--- a/addon/mixins/keyboard-first-responder-on-focus.js
+++ b/addon/mixins/keyboard-first-responder-on-focus.js
@@ -16,6 +16,9 @@ export default Mixin.create({
   }),
 
   resignFirstResponderOnFocusOut: on('focusOut', function() {
-    set(this, 'keyboardFirstResponder', false);
+    setProperties(this, {
+      keyboardActivated: false,
+      keyboardFirstResponder: false
+    });
   })
 });

--- a/addon/mixins/keyboard-first-responder-on-focus.js
+++ b/addon/mixins/keyboard-first-responder-on-focus.js
@@ -16,6 +16,6 @@ export default Mixin.create({
   }),
 
   resignFirstResponderOnFocusOut: on('focusOut', function() {
-    set('keyboardFirstResponder', false);
+    set(this, 'keyboardFirstResponder', false);
   })
 });


### PR DESCRIPTION
…to address {{input}} and {{textarea}} components not allowing events to flow after 'focusOut'