### PR TITLE
Allow using `cmd` as DSL for ctrl or command key.

### DIFF
--- a/addon/listeners/key-events.js
+++ b/addon/listeners/key-events.js
@@ -3,7 +3,7 @@ import codeMap from 'ember-keyboard/fixtures/code-map';
 import listenerName from 'ember-keyboard/utils/listener-name';
 
 const keyMapValues = Object.keys(codeMap).map((key) => codeMap[key]);
-const validKeys = keyMapValues.concat(['alt', 'ctrl', 'meta', 'shift']);
+const validKeys = keyMapValues.concat(['alt', 'ctrl', 'meta', 'shift', 'cmd']);
 
 const validateKeys = function validateKeys(keys) {
   keys.forEach((key) => {

--- a/addon/utils/get-cmd-key.js
+++ b/addon/utils/get-cmd-key.js
@@ -1,0 +1,7 @@
+export default function translateCmd(platform=navigator.platform) {
+  if (platform.indexOf('Mac') > -1) {
+    return 'meta';
+  } else {
+    return 'ctrl';
+  }
+}

--- a/addon/utils/handle-key-event.js
+++ b/addon/utils/handle-key-event.js
@@ -10,7 +10,7 @@ const {
 const gatherKeys = function gatherKeys(event) {
   const key = getCode(event);
 
-  return ['ctrl', 'meta', 'alt', 'shift'].reduce((keys, keyName) => {
+  return ['alt', 'ctrl', 'meta', 'shift'].reduce((keys, keyName) => {
     if (event[`${keyName}Key`]) {
       keys.push(keyName);
     }

--- a/addon/utils/listener-name.js
+++ b/addon/utils/listener-name.js
@@ -1,8 +1,14 @@
+import getCmdKey from 'ember-keyboard/utils/get-cmd-key';
+
 function sortedKeys(keyArray) {
   return keyArray.sort().join('+');
 }
 
 export default function listenerName(type, keyArray = []) {
+  if (keyArray.indexOf('cmd') > -1) {
+    keyArray[keyArray.indexOf('cmd')] = getCmdKey();
+  }
+
   const keys = keyArray.length === 0 ? '_all' : sortedKeys(keyArray);
 
   return `${type}:${keys}`;

--- a/app/utils/get-cmd-key.js
+++ b/app/utils/get-cmd-key.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-keyboard/utils/get-cmd-key';

--- a/tests/dummy/app/templates/usage.hbs
+++ b/tests/dummy/app/templates/usage.hbs
@@ -120,6 +120,20 @@ triggerOnAlphaNumeric: Ember.on(keyUp(), function(event) {
 })
 ```
 
+### `cmd` keycode
+
+It is very common for macOS users to expect to use key combinations such as
+Command(⌘)+Key vs. Ctrl+Key. Therefore, we provide a special key definiton,
+`cmd` to allow handling this behavior. For instance this defintion:
+
+```js
+triggerSubmit: Ember.on(keyDown('Enter+cmd'), function() {
+  this.submit();
+});
+```
+
+will trigger on Command(⌘)+Enter on macOS or Ctrl+Enter on all other platforms.
+
 ### `Ember.TextField` && `Ember.TextArea`
 
 To prevent `ember-keyboard` from responding to key strokes while an input/textarea is focused, we've reopened `Ember.TextField` and `Ember.TextArea` and applied the `EKOnInsertMixin` and `EKFirstResponderOnFocusMixin`. This ensures that whenever an input is focused, other key responders will not fire. If you want to have responders associated with an input or textarea (such as a rich text editor with `keyUp('ctrl+i')` bindings), you need to extend these components from `Ember.TextField` or `Ember.TextArea` rather than `Ember.component`.

--- a/tests/unit/utils/get-cmd-key-test.js
+++ b/tests/unit/utils/get-cmd-key-test.js
@@ -1,0 +1,24 @@
+import getCmdKey from 'dummy/utils/get-cmd-key';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | get cmd key');
+
+test('it returns ctrl for windows', function(assert) {
+  let result = getCmdKey('Windows');
+  assert.equal(result, 'ctrl');
+});
+
+test('it returns ctrl for linux', function(assert) {
+  let result = getCmdKey('Linux');
+  assert.equal(result, 'ctrl');
+});
+
+test('it defaults to ctlr for unexpected platform', function(assert) {
+  let result = getCmdKey('NeXTSTEP');
+  assert.equal(result, 'ctrl');
+});
+
+test('it returns meta (command) for macOS', function(assert) {
+  let result = getCmdKey('MacIntel');
+  assert.equal(result, 'meta');
+});

--- a/tests/unit/utils/listener-name-test.js
+++ b/tests/unit/utils/listener-name-test.js
@@ -1,5 +1,6 @@
 import listenerName from '../../../utils/listener-name';
 import { module, test } from 'qunit';
+import getCmdKey from 'ember-keyboard/utils/get-cmd-key';
 
 module('Unit | Utility | listener name');
 
@@ -13,4 +14,11 @@ test('it returns `_all` if the keys array is empty', function(assert) {
   const result = listenerName('keydown');
 
   assert.equal(result, 'keydown:_all', 'name is correctly formatted');
+});
+
+test('it replaces cmd with the platform appropriate key', function(assert) {
+  const result = listenerName('keydown', ['Enter', 'cmd']);
+
+  assert.equal(result, `keydown:Enter+${getCmdKey()}`);
+  assert.equal(result.indexOf('cmd'), -1);
 });


### PR DESCRIPTION
Users of macOS expect to press Command+Key whereas Windows, Linux, etc.
expect to press Ctrl+Key. This allows easily defining that behavior.
Fixes #38.