### PR TITLE
Fix a bug with unregistering jquery listeners

### DIFF
--- a/addon/services/keyboard.js
+++ b/addon/services/keyboard.js
@@ -43,7 +43,7 @@ export default Service.extend({
     });
   },
 
-  isDestroying(...args) {
+  willDestroy(...args) {
     this._super(...args);
 
     Ember.$(document).off('.ember-keyboard-listener');

--- a/tests/unit/services/keyboard-test.js
+++ b/tests/unit/services/keyboard-test.js
@@ -43,10 +43,22 @@ test('`sortedResponders` sorts by keyboardFirstResponder and keyboardPriority', 
   assert.deepEqual(service.get('sortedResponders').mapBy('keyboardPriority'), [0, 1, 0, -1], 'correct sorting');
 });
 
-test('`isDestroying` removes the jquery listeners', function(assert) {
+test('`willDestroy` removes the jquery listeners', function(assert) {
   const service = this.subject();
 
-  service.isDestroying();
+  service.willDestroy();
+
+  const listeners = Ember.$._data(document);
+
+  assert.ok(!get(listeners, 'events.keyup'), 'listeners have been removed');
+});
+
+test('`destroy` removes the jquery listeners', function(assert) {
+  const service = this.subject();
+
+  Ember.run(() => {
+    service.destroy();
+  });
 
   const listeners = Ember.$._data(document);
 


### PR DESCRIPTION
This PR fixes an issue with unregistering event listeners.  This is a pretty minor bug with respect to production code, but can lead to some pretty severe memory leaks in a testing environment. Lingering listeners tend to retain a fairly large chunk of memory through their own references to things.

To fix this issue, we just switch from using [`isDestroying`](http://emberjs.com/api/classes/Ember.Service.html#property_isDestroying) to [`willDestroy`](http://emberjs.com/api/classes/Ember.Service.html#method_willDestroy)

I also added an additional test that calls `service.destroy` from within the Ember run loop to verify that `willDestroy` gets called properly.