### PR TITLE
Bugfix in utils/get-cmd-key: problem with fastboot

### DIFF
--- a/addon/utils/get-cmd-key.js
+++ b/addon/utils/get-cmd-key.js
@@ -1,7 +1,12 @@
-export default function translateCmd(platform=navigator.platform) {
-  if (platform.indexOf('Mac') > -1) {
-    return 'meta';
-  } else {
-    return 'ctrl';
+export default function(platform) {
+  if (typeof FastBoot === 'undefined') {
+    if (platform === undefined) {
+      platform = navigator.platform;
+    }
+    if (platform.indexOf('Mac') > -1) {
+      return 'meta';
+    } else {
+      return 'ctrl';
+    }
   }
 }


### PR DESCRIPTION
A simple fix for an error occurring in fastboot.