### PR TITLE
Event propagation

### DIFF
--- a/addon/utils/handle-key-event.js
+++ b/addon/utils/handle-key-event.js
@@ -1,14 +1,8 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
 import getCode from 'ember-keyboard/utils/get-code';
 import listenerName from 'ember-keyboard/utils/listener-name';
 
-const {
-  hasListeners,
-  get,
-  getProperties
-} = Ember;
-
-const gatherKeys = function gatherKeys(event) {
+function gatherKeys(event) {
   const key = getCode(event);
 
   return ['alt', 'ctrl', 'meta', 'shift'].reduce((keys, keyName) => {
@@ -18,7 +12,7 @@ const gatherKeys = function gatherKeys(event) {
 
     return keys;
   }, [key]);
-};
+}
 
 export default function handleKeyEvent(event, sortedResponders) {
   let currentPriorityLevel;
@@ -29,7 +23,9 @@ export default function handleKeyEvent(event, sortedResponders) {
   const listenerNames = [listenerName(event.type, keys), listenerName(event.type)];
 
   sortedResponders.every((responder) => {
-    const { keyboardFirstResponder, keyboardPriority } = getProperties(responder, 'keyboardFirstResponder', 'keyboardPriority');
+    const keyboardFirstResponder = get(responder, 'keyboardFirstResponder');
+    const keyboardPriority = get(responder, 'keyboardPriority');
+
     if (keyboardFirstResponder || (noFirstResponders && keyboardPriority >= currentPriorityLevel) || isLax) {
       if (!get(responder, 'keyboardLaxPriority')) {
         isLax = false;
@@ -42,7 +38,7 @@ export default function handleKeyEvent(event, sortedResponders) {
       }
 
       listenerNames.forEach((triggerName) => {
-        if (hasListeners(responder, triggerName)) {
+        if (responder.has(triggerName)) {
           responder.trigger(triggerName, event);
         }
       });

--- a/addon/utils/handle-key-event.js
+++ b/addon/utils/handle-key-event.js
@@ -14,7 +14,11 @@ function gatherKeys(event) {
   }, [key]);
 }
 
-export default function handleKeyEvent(event, sortedResponders) {
+export function handleKeyEventWithPropagation(event, { firstResponders, normalResponders }) {
+
+}
+
+export function handleKeyEventWithLaxPriorities(event, sortedResponders) {
   let currentPriorityLevel;
   let noFirstResponders = true;
   let isLax = true;

--- a/tests/acceptance/ember-keyboard-test.js
+++ b/tests/acceptance/ember-keyboard-test.js
@@ -1,4 +1,5 @@
 import { run } from '@ember/runloop';
+import { set } from '@ember/object';
 import { module, test } from 'qunit';
 import startApp from '../../tests/helpers/start-app';
 import { hook } from 'ember-hook';
@@ -60,5 +61,66 @@ test('test standard functionality', function(assert) {
     return keyUp('KeyR');
   }).then(() => {
     assert.deepEqual(getValues(), [3, 0, 0], 'keyUp works');
+  });
+});
+
+test('test event propagation', function(assert) {
+  assert.expect(6);
+
+  const keyboardService = this.application.__container__.lookup('service:keyboard');
+  set(keyboardService, 'isPropagationEnabled', true);
+
+  visit('/test-scenario').then(() => {
+    return keyDown('ArrowRight');
+  }).then(() => {
+    assert.deepEqual(getValues(), [1, 1, 1], 'equal responders all respond');
+
+    fillIn(`${hook('counter')}:nth(0) ${hook('counter-priority-input')}`, '1');
+
+    triggerEvent(`${hook('counter')}:nth(0) ${hook('counter-priority-input')}`, 'blur');
+
+    return keyDown('ArrowRight');
+  }).then(() => {
+    assert.deepEqual(getValues(), [2, 2, 2], 'highest responder responds first, lower responders follow');
+
+    fillIn(`${hook('counter')}:nth(1) ${hook('counter-priority-input')}`, '1');
+
+    triggerEvent(`${hook('counter')}:nth(1) ${hook('counter-priority-input')}`, 'blur');
+
+    click(`${hook('counter')}:nth(0) ${hook('counter-stop-immediate-propagation-toggle')}`);
+
+    return keyDown('ArrowRight');
+  }).then(() => {
+    assert.deepEqual(getValues(), [3, 2, 3], 'highest responder responds first and stops immediate propagation, lower responders follow');
+
+    click(`${hook('counter')}:nth(0) ${hook('counter-stop-immediate-propagation-toggle')}`);
+
+    click(`${hook('counter')}:nth(0) ${hook('counter-stop-propagation-toggle')}`);
+
+
+    return keyDown('ArrowRight');
+  }).then(() => {
+    assert.deepEqual(getValues(), [4, 3, 3], 'highest responders responds first and block propagation to lower priority responders');
+
+    click(`${hook('counter')}:nth(0) ${hook('counter-activated-toggle')}`);
+
+    return keyDown('ArrowRight');
+  }).then(() => {
+    assert.deepEqual(getValues(), [4, 4, 4], 'deactivating a responder removes it from the stack, deactivated responders do not block propagation');
+
+    fillIn(`${hook('counter')}:nth(0) ${hook('counter-priority-input')}`, '2');
+    triggerEvent(`${hook('counter')}:nth(0) ${hook('counter-priority-input')}`, 'blur');
+    click(`${hook('counter')}:nth(0) ${hook('counter-stop-propagation-toggle')}`);
+    click(`${hook('counter')}:nth(0) ${hook('counter-activated-toggle')}`);
+    click(`${hook('counter')}:nth(0) ${hook('counter-first-responder-toggle')}`)
+    ;
+    click(`${hook('counter')}:nth(1) ${hook('counter-first-responder-toggle')}`);
+    click(`${hook('counter')}:nth(1) ${hook('counter-stop-immediate-propagation-toggle')}`);
+
+    click(`${hook('counter')}:nth(2) ${hook('counter-first-responder-toggle')}`);
+
+    return keyDown('ArrowRight');
+  }).then(() => {
+    assert.deepEqual(getValues(), [5, 5, 4], 'first responders get called in priority order.');
   });
 });

--- a/tests/acceptance/ember-keyboard-test.js
+++ b/tests/acceptance/ember-keyboard-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import startApp from '../../tests/helpers/start-app';
 import { hook } from 'ember-hook';
@@ -15,7 +15,7 @@ module('Acceptance | ember keyboard', {
   },
 
   afterEach() {
-    Ember.run(this.application, 'destroy');
+    run(this.application, 'destroy');
   }
 });
 

--- a/tests/dummy/app/components/key-down-counter.js
+++ b/tests/dummy/app/components/key-down-counter.js
@@ -1,11 +1,19 @@
-import Ember from 'ember';
+import { get, computed } from '@ember/object';
+import { on } from '@ember/object/evented';
+import Component from '@ember/component';
 import { EKMixin, keyDown, keyUp, keyPress } from 'ember-keyboard';
 
-const {
-  Component,
-  computed,
-  on
-} = Ember;
+function makeEventHandler(stepSize = 1) {
+  return function(event, ekEvent) {
+    if (get(this, 'stopImmediatePropagation')) {
+      ekEvent.stopImmediatePropagation();
+    }
+    if (get(this, 'stopPropagation')) {
+      ekEvent.stopPropagation();
+    }
+    this.incrementProperty('counter', stepSize);
+  }
+}
 
 export default Component.extend(EKMixin, {
   tagName: 'span',
@@ -23,29 +31,17 @@ export default Component.extend(EKMixin, {
     }
   }).readOnly(),
 
-  decrementCounter: on(keyDown('ArrowLeft'), function() {
-    this.decrementProperty('counter');
-  }),
+  decrementCounter: on(keyDown('ArrowLeft'), makeEventHandler(-1)),
 
-  incrementCounter: on(keyDown('ArrowRight'), function() {
-    this.incrementProperty('counter');
-  }),
+  incrementCounter: on(keyDown('ArrowRight'), makeEventHandler(1)),
 
-  decrementCounter10: on(keyDown('shift+ArrowLeft'), function() {
-    this.decrementProperty('counter', 10);
-  }),
+  decrementCounter10: on(keyDown('shift+ArrowLeft'), makeEventHandler(-10)),
 
-  incrementCounter10: on(keyDown('shift+ArrowRight'), function() {
-    this.incrementProperty('counter', 10);
-  }),
+  incrementCounter10: on(keyDown('shift+ArrowRight'), makeEventHandler(10)),
 
-  decrementCounter100: on(keyDown('ctrl+shift+ArrowLeft'), function() {
-    this.decrementProperty('counter', 100);
-  }),
+  decrementCounter100: on(keyDown('ctrl+shift+ArrowLeft'), makeEventHandler(-100)),
 
-  incrementCounter100: on(keyDown('ctrl+shift+ArrowRight'), function() {
-    this.incrementProperty('counter', 100);
-  }),
+  incrementCounter100: on(keyDown('ctrl+shift+ArrowRight'), makeEventHandler(100)),
 
   resetCounter: on(keyUp('KeyR'), function() {
     this.set('counter', 0);

--- a/tests/dummy/app/components/keyboard-propagation-widget.js
+++ b/tests/dummy/app/components/keyboard-propagation-widget.js
@@ -1,0 +1,20 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { set } from '@ember/object';
+import EnterableMixin from 'dummy/mixins/enterable';
+
+export default Component.extend(EnterableMixin, {
+  keyboard: service(),
+
+  _activate() {
+    this._super(...arguments);
+
+    set(this, 'keyboard.isPropagationEnabled', true);
+  },
+
+  deactivate() {
+    this._super(...arguments);
+
+    set(this, 'keyboard.isPropagationEnabled', false);
+  }
+});

--- a/tests/dummy/app/templates/components/key-down-counter.hbs
+++ b/tests/dummy/app/templates/components/key-down-counter.hbs
@@ -18,4 +18,14 @@
   {{input type="checkbox" checked=keyboardLaxPriority classNames="checkbox" hook="counter-lax-priority-toggle"}}
 {{/if}}
 
+{{#if stopImmediatePropagationToggle}}
+  <label><code>stopImmediatePropagation()</code>:</label>
+  {{input type="checkbox" checked=stopImmediatePropagation classNames="checkbox" hook="counter-stop-immediate-propagation-toggle"}}
+{{/if}}
+
+{{#if stopPropagationToggle}}
+  <label><code>stopPropagation()</code>:</label>
+  {{input type="checkbox" checked=stopPropagation classNames="checkbox" hook="counter-stop-propagation-toggle"}}
+{{/if}}
+
 <div data-test={{hook "counter-counter"}}>{{counter}}</div>

--- a/tests/dummy/app/templates/components/keyboard-propagation-widget.hbs
+++ b/tests/dummy/app/templates/components/keyboard-propagation-widget.hbs
@@ -1,0 +1,88 @@
+{{format-markdown "
+### Event propagation
+
+By setting `emberKeyboard.propagate` in the `config/environment.js` to `true`,
+you're opting into the new event propagation semantics that were introduced in
+[issue #63](https://github.com/null-null-null/ember-keyboard/issues/63).
+
+The event propagation is designed to mirror how standard DOM events bubble up
+the parent node chain and supports calling a
+[`stopPropagation()` method](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation)
+and
+[`stopImmediatePropagation()` method](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopImmediatePropagation)
+on a second event object pased to your handlers.
+
+```js
+incrementCounter: on(keyDown('RightArrow'), function(event, ekEvent) {
+  const key = getCode(event); // => 'RightArrow'
+  // ekEvent.stopPropagation();
+  // ekEvent.stopImmediatePropagation();
+})
+```
+
+Instead of traversing up the parent node chain, `ember-keyboard` walks down the
+priority list. This means that all responders with `keyboardFirstResponder` set
+to `true` will be called first in descending order of their `keyboardPriority`,
+followed by all normal responders in descending order of their `keyboardPriority`.
+
+Calling `stopPropagation()` during the first responder phase will allow all
+first responders to get triggered, but will prevent all normal responder to get
+triggered.
+
+If you call `stopImmediatePropagation()` during that phase, all following first
+responders that have not been triggered yet will be skipped. Event propagation
+then continues with the normal responders.
+
+You may call both methods.
+
+Calling `stopPropagation()` during the normal responder phase will allow all
+responders of the same priority level to get triggered. Lower priority
+responders will not get triggered.
+
+Calling `stopImmediatePropagation()` during that phase will prevent all
+responders of the same priority level that have not been triggered yet from
+getting triggered. Event propagation then continues with the next lower priority
+level responders.
+
+Again, you may call both methods.
+
+Setting `keyboardLaxPriority` will have no effect, since the semantics are
+fundamentally incompatible. The major advantage of the new event propagation is,
+that higher priority responders get to decide on a per-event basis which events
+to 'catch' and which not as opposed to setting or not setting
+`keyboardLaxPriority` which either 'catches' no or all events.
+"}}
+
+{{key-down-counter
+  parentActivated=keyboardActivated
+  priorityInput=true
+  activatedToggle=true
+  firstResponderToggle=true
+  stopImmediatePropagationToggle=true
+  stopPropagationToggle=true
+  keyboardPriority=2
+  keyboardFirstResponder=true
+  stopImmediatePropagation=true
+  hook="propagation-counter"
+}}
+{{key-down-counter
+  parentActivated=keyboardActivated
+  priorityInput=true
+  activatedToggle=true
+  firstResponderToggle=true
+  stopImmediatePropagationToggle=true
+  stopPropagationToggle=true
+  keyboardPriority=1
+  keyboardFirstResponder=true
+  stopPropagation=true
+  hook="propagation-counter"
+}}
+{{key-down-counter
+  parentActivated=keyboardActivated
+  priorityInput=true
+  activatedToggle=true
+  firstResponderToggle=true
+  stopImmediatePropagationToggle=true
+  stopPropagationToggle=true
+  hook="propagation-counter"
+}}

--- a/tests/dummy/app/templates/priority.hbs
+++ b/tests/dummy/app/templates/priority.hbs
@@ -19,3 +19,5 @@ Controls:
 {{keyboard-first-responder-widget}}
 
 {{keyboard-lax-priority-widget}}
+
+{{keyboard-propagation-widget}}

--- a/tests/dummy/app/templates/test-scenario.hbs
+++ b/tests/dummy/app/templates/test-scenario.hbs
@@ -1,3 +1,27 @@
-{{key-down-counter parentActivated=true priorityInput=true activatedToggle=true firstResponderToggle=true laxPriorityToggle=true}}
-{{key-down-counter parentActivated=true priorityInput=true activatedToggle=true firstResponderToggle=true laxPriorityToggle=true}}
-{{key-down-counter parentActivated=true priorityInput=true activatedToggle=true firstResponderToggle=true laxPriorityToggle=true}}
+{{key-down-counter
+  parentActivated=true
+  priorityInput=true
+  activatedToggle=true
+  firstResponderToggle=true
+  laxPriorityToggle=true
+  stopImmediatePropagationToggle=true
+  stopPropagationToggle=true
+}}
+{{key-down-counter
+  parentActivated=true
+  priorityInput=true
+  activatedToggle=true
+  firstResponderToggle=true
+  laxPriorityToggle=true
+  stopImmediatePropagationToggle=true
+  stopPropagationToggle=true
+}}
+{{key-down-counter
+  parentActivated=true
+  priorityInput=true
+  activatedToggle=true
+  firstResponderToggle=true
+  laxPriorityToggle=true
+  stopImmediatePropagationToggle=true
+  stopPropagationToggle=true
+}}


### PR DESCRIPTION
Closes #63.

While working on this I've realized that `keyboardLaxPriority` is fundamentally incompatible with `stopPropagation`, since the latter expects events to 'bubble' by default. Therefore user have to opt in to the new semantics by setting `emberKeyboard.propagate` to `true` in their config. This option can also be set at run time on the `keyboard` service as `isPropagationEnabled`.

Only if `isPropagationEnabled` is `true`, the second `ekEvent` argument is passed to the event listeners.

The semantics are explained in the docs, but for easier access, I'll quote them here:

> By setting `emberKeyboard.propagate` in the `config/environment.js` to `true`,
> you're opting into the new event propagation semantics that were introduced in
> [issue #63](https://github.com/null-null-null/ember-keyboard/issues/63).
>
> The event propagation is designed to mirror how standard DOM events bubble up
> the parent node chain and supports calling a [`stopPropagation()` method](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation) and [`stopImmediatePropagation()` method](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopImmediatePropagation) on a second event object pased to your handlers.
>
> ```js
> incrementCounter: on(keyDown('RightArrow'), function(event, ekEvent) {
>   const key = getCode(event); // => 'RightArrow'
>   // ekEvent.stopPropagation();
>   // ekEvent.stopImmediatePropagation();
> })
> ```
>
> Instead of traversing up the parent node chain, `ember-keyboard` walks down the
> priority list. This means that all responders with `keyboardFirstResponder` set
> to `true` will be called first in descending order of their `keyboardPriority`,
> followed by all normal responders in descending order of their `keyboardPriority`.
> Calling `stopPropagation()` during the first responder phase will allow all
> first responders to get triggered, but will prevent all normal responder to get
> triggered.
>
> If you call `stopImmediatePropagation()` during that phase, all following first
> responders that have not been triggered yet will be skipped. Event propagation
> then continues with the normal responders.
>
> You may call both methods.
>
> Calling `stopPropagation()` during the normal responder phase will allow all
> responders of the same priority level to get triggered. Lower priority
> responders will not get triggered.
>
> Calling `stopImmediatePropagation()` during that phase will prevent all
> responders of the same priority level that have not been triggered yet from
> getting triggered. Event propagation then continues with the next lower priority
> level responders.
>
> Again, you may call both methods.
>
> Setting `keyboardLaxPriority` will have no effect, since the semantics are
> fundamentally incompatible. The major advantage of the new event propagation is,
> that higher priority responders get to decide on a per-event basis which events
> to 'catch' and which not as opposed to setting or not setting
> `keyboardLaxPriority` which either 'catches' no or all events.