### PR TITLE
docs: fix syntax highlighting

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,8 +5,12 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    babel: {
+      includePolyfill: true
+    }
   });
+
+  app.import('bower_components/highlightjs/styles/monokai-sublime.css');
 
   /*
     This build file specifies the options for the dummy test app of this


### PR DESCRIPTION
Was accidentally removed in 8ed8fe7354df2e3061d642b0a5bf252360f4226a